### PR TITLE
New VK conditions

### DIFF
--- a/lib/UIApi.py
+++ b/lib/UIApi.py
@@ -29,7 +29,8 @@ if sys.argv[curl_params_index] != 'curl':
     sys.exit(1)
 
 _HEADERS = {}
-needed_headers = ['Authorization', 'Cookie']
+#needed_headers = ['Authorization', 'Cookie']
+needed_headers = ['Cookie']
 process_arg = curl_params_index # Starting with curl_params_index to not process vk-backup params
 while process_arg < len(sys.argv)-1:
     process_arg += 1


### PR DESCRIPTION
09.17.2025 Authorized in VK via Firefox (there the cURL request is immediately issued in one line, unlike Google Chrome), but there is no "Authorization" header, so I removed this check in the code